### PR TITLE
README: Add License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,7 @@ responsive_image_tag('/bird.jpg', width: 1200, sizes: { phone: 600, tablet: 800 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## License
+
+This project is licensed and distributed under the terms of the [MIT license](https://github.com/resume-io/carrierwave-cloudflare/blob/master/LICENSE.txt). 


### PR DESCRIPTION
To be explicit that package is distributed under MIT and resume.io / Talent Inc. owns no intellectual rights.