### PR TITLE
Set `width` and `height` attributes to the image tag if values exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+CHANGELOG
+
+== 0.4.0 (2022-07-18)
+
+- Set `width` and `height` attributes to the image tag if values exist

--- a/carrierwave-cloudflare.gemspec
+++ b/carrierwave-cloudflare.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rubocop"
 end

--- a/lib/carrierwave/cloudflare/action_view/responsive_images_helper.rb
+++ b/lib/carrierwave/cloudflare/action_view/responsive_images_helper.rb
@@ -47,6 +47,8 @@ module CarrierWave
           image_tag(
             cdn_transformed(url, **transform),
             srcset: hidpi_image_srcset(url, dprs: dprs, **transform),
+            width: transform[:width],
+            height: transform[:height],
             **rest
           )
         end
@@ -73,7 +75,7 @@ module CarrierWave
           url = url.url if url.is_a?(CarrierWave::Uploader)
 
           if sizes.nil?
-            return hidpi_image_tag(url, **options)
+            return hidpi_image_tag(url, width: width, **options)
           end
 
           sizes[:default] = width
@@ -108,6 +110,8 @@ module CarrierWave
             base_version,
             srcset: srcset,
             sizes: sizes_attr,
+            width: width,
+            height: transform[:height],
             **rest
           )
         end

--- a/lib/carrierwave/cloudflare/version.rb
+++ b/lib/carrierwave/cloudflare/version.rb
@@ -2,6 +2,6 @@
 
 module CarrierWave
   module Cloudflare
-    VERSION = "0.3.2"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/carrierwave/cloudflare/responsive_images_helper_spec.rb
+++ b/spec/carrierwave/cloudflare/responsive_images_helper_spec.rb
@@ -52,7 +52,15 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
 
       it "generates image tag with srcset" do
         img_tag = view.hidpi_image_tag("/img.jpg", width: 400, dprs: [1, 2, 3])
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,dpr=3/img.jpg 3x\" src=\"/cdn-cgi/image/width=400/img.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,dpr=3/img.jpg 3x\" width=\"400\" src=\"/cdn-cgi/image/width=400/img.jpg\" />"
+
+        expect(img_tag).to eql(expected_img_tag)
+      end
+
+      it "generates image tag with width and height" do
+        img_tag = view.hidpi_image_tag("/img.jpg", width: 400, height: 300, dprs: [1, 2, 3])
+
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,height=300,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,height=300,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,height=300,dpr=3/img.jpg 3x\" width=\"400\" height=\"300\" src=\"/cdn-cgi/image/width=400,height=300/img.jpg\" />"
 
         expect(img_tag).to eql(expected_img_tag)
       end
@@ -90,7 +98,16 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
       it "generates image responsive image tag" do
         img_tag = view.responsive_image_tag('/bird.jpg', width: 1200, sizes: { phone: 600, tablet: 800 })
 
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=1200,dpr=0.5/bird.jpg 600w, /cdn-cgi/image/width=1200,dpr=1.0/bird.jpg 1200w, /cdn-cgi/image/width=1200,dpr=0.67/bird.jpg 800w, /cdn-cgi/image/width=1200,dpr=1.33/bird.jpg 1600w, /cdn-cgi/image/width=1200,dpr=2.0/bird.jpg 2400w\" sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 1200px\" src=\"/cdn-cgi/image/width=1200/bird.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=1200,dpr=0.5/bird.jpg 600w, /cdn-cgi/image/width=1200,dpr=1.0/bird.jpg 1200w, /cdn-cgi/image/width=1200,dpr=0.67/bird.jpg 800w, /cdn-cgi/image/width=1200,dpr=1.33/bird.jpg 1600w, /cdn-cgi/image/width=1200,dpr=2.0/bird.jpg 2400w\" sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 1200px\" width=\"1200\" src=\"/cdn-cgi/image/width=1200/bird.jpg\" />"
+
+
+        expect(img_tag).to eql(expected_img_tag)
+      end
+
+      it "generates image responsive image tag with height" do
+        img_tag = view.responsive_image_tag('/bird.jpg', width: 200, height: 1200, sizes: { phone: 600, tablet: 800 })
+
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=200,height=1200,dpr=3.0/bird.jpg 600w, /cdn-cgi/image/width=200,height=1200,dpr=6.0/bird.jpg 1200w, /cdn-cgi/image/width=200,height=1200,dpr=4.0/bird.jpg 800w, /cdn-cgi/image/width=200,height=1200,dpr=8.0/bird.jpg 1600w, /cdn-cgi/image/width=200,height=1200,dpr=1.0/bird.jpg 200w, /cdn-cgi/image/width=200,height=1200,dpr=2.0/bird.jpg 400w\" sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 200px\" width=\"200\" height=\"1200\" src=\"/cdn-cgi/image/width=200,height=1200/bird.jpg\" />"
 
 
         expect(img_tag).to eql(expected_img_tag)

--- a/spec/carrierwave/cloudflare/responsive_images_helper_spec.rb
+++ b/spec/carrierwave/cloudflare/responsive_images_helper_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
 
       it "generates image tag with srcset" do
         img_tag = view.hidpi_image_tag("/img.jpg", width: 400, dprs: [1, 2, 3])
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,dpr=3/img.jpg 3x\" width=\"400\" src=\"/cdn-cgi/image/width=400/img.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,dpr=1/img.jpg 1x,\
+ /cdn-cgi/image/width=400,dpr=2/img.jpg 2x,\
+ /cdn-cgi/image/width=400,dpr=3/img.jpg 3x\"\
+ width=\"400\" src=\"/cdn-cgi/image/width=400/img.jpg\" />"
 
         expect(img_tag).to eql(expected_img_tag)
       end
@@ -60,7 +63,10 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
       it "generates image tag with width and height" do
         img_tag = view.hidpi_image_tag("/img.jpg", width: 400, height: 300, dprs: [1, 2, 3])
 
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,height=300,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,height=300,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,height=300,dpr=3/img.jpg 3x\" width=\"400\" height=\"300\" src=\"/cdn-cgi/image/width=400,height=300/img.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=400,height=300,dpr=1/img.jpg 1x,\
+ /cdn-cgi/image/width=400,height=300,dpr=2/img.jpg 2x,\
+ /cdn-cgi/image/width=400,height=300,dpr=3/img.jpg 3x\"\
+ width=\"400\" height=\"300\" src=\"/cdn-cgi/image/width=400,height=300/img.jpg\" />"
 
         expect(img_tag).to eql(expected_img_tag)
       end
@@ -75,14 +81,16 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
 
       it "generates image srcset" do
         img_srcset = view.hidpi_image_srcset("/img.jpg", width: 400, dprs: [1, 2, 3])
-        expected_img_srcset = "/cdn-cgi/image/width=400,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,dpr=3/img.jpg 3x"
+        expected_img_srcset = "/cdn-cgi/image/width=400,dpr=1/img.jpg 1x,\
+ /cdn-cgi/image/width=400,dpr=2/img.jpg 2x, /cdn-cgi/image/width=400,dpr=3/img.jpg 3x"
 
         expect(img_srcset).to eql(expected_img_srcset)
       end
 
       it "generates image srcset (uses default drps)" do
         img_srcset = view.hidpi_image_srcset("/img.jpg", width: 400)
-        expected_img_srcset = "/cdn-cgi/image/width=400,dpr=1/img.jpg 1x, /cdn-cgi/image/width=400,dpr=2/img.jpg 2x"
+        expected_img_srcset = "/cdn-cgi/image/width=400,dpr=1/img.jpg 1x,\
+ /cdn-cgi/image/width=400,dpr=2/img.jpg 2x"
 
         expect(img_srcset).to eql(expected_img_srcset)
       end
@@ -98,7 +106,13 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
       it "generates image responsive image tag" do
         img_tag = view.responsive_image_tag('/bird.jpg', width: 1200, sizes: { phone: 600, tablet: 800 })
 
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=1200,dpr=0.5/bird.jpg 600w, /cdn-cgi/image/width=1200,dpr=1.0/bird.jpg 1200w, /cdn-cgi/image/width=1200,dpr=0.67/bird.jpg 800w, /cdn-cgi/image/width=1200,dpr=1.33/bird.jpg 1600w, /cdn-cgi/image/width=1200,dpr=2.0/bird.jpg 2400w\" sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 1200px\" width=\"1200\" src=\"/cdn-cgi/image/width=1200/bird.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=1200,dpr=0.5/bird.jpg 600w,\
+ /cdn-cgi/image/width=1200,dpr=1.0/bird.jpg 1200w,\
+ /cdn-cgi/image/width=1200,dpr=0.67/bird.jpg 800w,\
+ /cdn-cgi/image/width=1200,dpr=1.33/bird.jpg 1600w,\
+ /cdn-cgi/image/width=1200,dpr=2.0/bird.jpg 2400w\"\
+ sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px,\
+ 1200px\" width=\"1200\" src=\"/cdn-cgi/image/width=1200/bird.jpg\" />"
 
 
         expect(img_tag).to eql(expected_img_tag)
@@ -107,7 +121,14 @@ RSpec.describe CarrierWave::Cloudflare::ActionView::ResponsiveImagesHelper do
       it "generates image responsive image tag with height" do
         img_tag = view.responsive_image_tag('/bird.jpg', width: 200, height: 1200, sizes: { phone: 600, tablet: 800 })
 
-        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=200,height=1200,dpr=3.0/bird.jpg 600w, /cdn-cgi/image/width=200,height=1200,dpr=6.0/bird.jpg 1200w, /cdn-cgi/image/width=200,height=1200,dpr=4.0/bird.jpg 800w, /cdn-cgi/image/width=200,height=1200,dpr=8.0/bird.jpg 1600w, /cdn-cgi/image/width=200,height=1200,dpr=1.0/bird.jpg 200w, /cdn-cgi/image/width=200,height=1200,dpr=2.0/bird.jpg 400w\" sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 200px\" width=\"200\" height=\"1200\" src=\"/cdn-cgi/image/width=200,height=1200/bird.jpg\" />"
+        expected_img_tag = "<img srcset=\"/cdn-cgi/image/width=200,height=1200,dpr=3.0/bird.jpg 600w,\
+ /cdn-cgi/image/width=200,height=1200,dpr=6.0/bird.jpg 1200w,\
+ /cdn-cgi/image/width=200,height=1200,dpr=4.0/bird.jpg 800w,\
+ /cdn-cgi/image/width=200,height=1200,dpr=8.0/bird.jpg 1600w,\
+ /cdn-cgi/image/width=200,height=1200,dpr=1.0/bird.jpg 200w,\
+ /cdn-cgi/image/width=200,height=1200,dpr=2.0/bird.jpg 400w\"\
+ sizes=\"(max-width: 767px) 600px, (max-width: 1023px) 800px, 200px\"\
+ width=\"200\" height=\"1200\" src=\"/cdn-cgi/image/width=200,height=1200/bird.jpg\" />"
 
 
         expect(img_tag).to eql(expected_img_tag)


### PR DESCRIPTION
> SEO Issue to solve: Images on the pages are missing width and height tags.
> 
> Goal to achieve: Adding width and height tags to images should improve page load times which can improve page rankings.

![image](https://user-images.githubusercontent.com/4071096/179498147-0c590a4d-3350-4372-9af3-7da9fd0abdac.png)


Also, added rubocop to gemspec